### PR TITLE
Fix multiple definition linker error

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -2,6 +2,12 @@
 
 GDExtensionClassLibraryPtr class_library = NULL;
 
+struct Constructors constructors;
+struct Destructors destructors;
+struct Operators operators;
+struct Methods methods;
+struct API api;
+
 GDExtensionPropertyInfo make_property_full(
     GDExtensionVariantType type,
     const char *name,

--- a/src/api.h
+++ b/src/api.h
@@ -15,7 +15,7 @@ extern GDExtensionClassLibraryPtr class_library;
 
 // API methods.
 
-struct Constructors
+extern struct Constructors
 {
     GDExtensionPtrConstructor vector2_constructor_x_y;
     GDExtensionInterfaceStringNewWithUtf8Chars string_new_with_utf8_chars;
@@ -26,25 +26,25 @@ struct Constructors
     GDExtensionVariantFromTypeConstructorFunc variant_from_vector2_constructor;
 } constructors;
 
-struct Destructors
+extern struct Destructors
 {
     GDExtensionPtrDestructor string_destructor;
     GDExtensionPtrDestructor string_name_destructor;
     GDExtensionInterfaceVariantDestroy variant_destroy;
 } destructors;
 
-struct Operators
+extern struct Operators
 {
     GDExtensionPtrOperatorEvaluator string_name_equal;
 } operators;
 
-struct Methods
+extern struct Methods
 {
     GDExtensionMethodBindPtr object_emit_signal;
     GDExtensionMethodBindPtr node2d_set_position;
 } methods;
 
-struct API
+extern struct API
 {
     GDExtensionInterfaceClassdbGetMethodBind classdb_get_method_bind;
     GDExtensionInterfaceObjectMethodBindCall object_method_bind_call;


### PR DESCRIPTION
Fix these erros when linking 
```
/bin/ld: src/gdexample.os:(.bss+0x0): multiple definition of `constructors'; src/api.os:(.bss+0x68): first defined here
/bin/ld: src/gdexample.os:(.bss+0x38): multiple definition of `destructors'; src/api.os:(.bss+0xa0): first defined here
/bin/ld: src/gdexample.os:(.bss+0x50): multiple definition of `api'; src/api.os:(.bss+0x8): first defined here
/bin/ld: src/gdexample.os:(.bss+0xb0): multiple definition of `methods'; src/api.os:(.bss+0xc0): first defined here
/bin/ld: src/gdexample.os:(.bss+0xc0): multiple definition of `operators'; src/api.os:(.bss+0xb8): first defined here
/bin/ld: src/init.os:(.bss+0x0): multiple definition of `constructors'; src/api.os:(.bss+0x68): first defined here
/bin/ld: src/init.os:(.bss+0x38): multiple definition of `api'; src/api.os:(.bss+0x8): first defined here
/bin/ld: src/init.os:(.bss+0x98): multiple definition of `methods'; src/api.os:(.bss+0xc0): first defined here
/bin/ld: src/init.os:(.bss+0xa8): multiple definition of `destructors'; src/api.os:(.bss+0xa0): first defined here
/bin/ld: src/init.os:(.bss+0xc0): multiple definition of `operators'; src/api.os:(.bss+0xb8): first defined here
clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
```

This PR adds `extern` keyword before some structs to prevent multiple definition when including `api.h` and defines them at `api.c`.